### PR TITLE
Avoid division to zero

### DIFF
--- a/lib/tty/progressbar.rb
+++ b/lib/tty/progressbar.rb
@@ -136,7 +136,7 @@ module TTY
     #
     # @api public
     def ratio
-      proportion = (@current.to_f / total)
+      proportion = total && total > 0 ? (@current.to_f / total) : 0
       [[proportion, 0].max, 1].min
     end
 


### PR DESCRIPTION
Under some scenarios `total` can be zero so it tries to divide `@current` to zero